### PR TITLE
check original against wn when morphing

### DIFF
--- a/gown.go
+++ b/gown.go
@@ -9,6 +9,7 @@ type WN struct {
     senseIndex *senseIndex
     PosIndicies map[int]*dataIndex
     posData map[int]*dataFile
+    exceptions []map[string]string
 }
 
 func GetWordNetDictDir() (string, error) {

--- a/gown_test.go
+++ b/gown_test.go
@@ -29,3 +29,78 @@ func BenchmarkLookup(b *testing.B) {
         wn.Lookup("live")
     }
 }
+
+func TestMorph(t *testing.T) {
+    dictDir, _ := GetWordNetDictDir()
+    wn, _ := LoadWordNet(dictDir)
+    wn.InitMorphData(dictDir)
+    poses := []int {
+        POS_VERB, // are
+        POS_NOUN, // splits
+        POS_VERB, // splits
+        POS_VERB, // left
+        POS_NOUN, // trucks
+        POS_VERB, // saw
+        POS_NOUN, // children
+        POS_VERB, // swam
+        POS_NOUN, // remains
+        POS_VERB, // remains
+        POS_NOUN, // plant
+        POS_NOUN, // Angus
+        POS_VERB, // walked
+        POS_NOUN, // park
+        POS_VERB, // jumping
+        POS_NOUN, // octopuses
+        POS_NOUN, // octopi
+        POS_NOUN, // octopus
+    }
+    inputs := []string {
+        "are",
+        "splits",
+        "splits",
+        "left",
+        "trucks",
+        "saw",
+        "children",
+        "swam",
+        "remains",
+        "remains",
+        "plant",
+        "Angus",
+        "walked",
+        "park",
+        "jumping",
+        "octopuses",
+        "octopi",
+        "octopus",
+    }
+    expecteds := []string {
+        "be",
+        "split",
+        "split",
+        "leave",
+        "truck",
+        "see",
+        "child",
+        "swim",
+        "remains",
+        "remain",
+        "plant",
+        "Angus",
+        "walk",
+        "park",
+        "jump",
+        "octopus",
+        "octopus",
+        "octopus",
+    }
+
+    for i, pos := range poses {
+        input := inputs[i]
+        expected := expecteds[i]
+        actual := wn.Morph(input, pos)
+        if actual != expected {
+            t.Errorf("for %s/%d expected %s but got %s\n", input, pos, expected, actual)
+        }
+    }
+}

--- a/morph.go
+++ b/morph.go
@@ -37,16 +37,16 @@ var (
             "est": []string { "", "e"},
         },
     }
+)
 
-    exceptions []map[string]string = []map[string]string {
+func (wn *WN) InitMorphData(dictDirname string) {
+    wn.exceptions = []map[string]string {
         map[string]string{},    // noun
         map[string]string{},    // verb
         map[string]string{},    // adjective
         map[string]string{},    // adverb
     }
-)
 
-func (wn *WN) InitMorphData(dictDirname string) {
     posNames := []string { "noun", "verb", "adj", "adv" }
     for posIndex, posName := range posNames {
         exceptionFilename := dictDirname + string(filepath.Separator) + posName + ".exc"
@@ -71,7 +71,7 @@ func (wn *WN) InitMorphData(dictDirname string) {
             fields := strings.SplitN(strings.TrimSpace(string(bytebuf)), " ", -1)
             derivedForm := strings.Replace(fields[0], "_", " ", -1)
             baseForm := strings.Replace(fields[1], "_", " ", -1)
-            exceptions[posIndex][derivedForm] = baseForm
+            wn.exceptions[posIndex][derivedForm] = baseForm
         }
         infile.Close()
     }
@@ -92,7 +92,7 @@ func (wn *WN) Morph(origword string, partOfSpeech int) string {
     }
 
     // check the exception lists
-    lemma, exists := exceptions[partOfSpeechIndex][origword]
+    lemma, exists := wn.exceptions[partOfSpeechIndex][origword]
     if exists {
         return lemma
     } else {

--- a/morph.go
+++ b/morph.go
@@ -46,7 +46,7 @@ var (
     }
 )
 
-func InitiMorphData(dictDirname string) {
+func (wn *WN) InitMorphData(dictDirname string) {
     posNames := []string { "noun", "verb", "adj", "adv" }
     for posIndex, posName := range posNames {
         exceptionFilename := dictDirname + string(filepath.Separator) + posName + ".exc"
@@ -81,6 +81,9 @@ func InitiMorphData(dictDirname string) {
 // Returns a lemmatizations for the word. We assume the word is in the
 // raw form. (i.e. spaces are spaces, not '_') This algorithim is similar to,
 // but not exactly the same as the Wordnet Morphy algorithm.
+//
+// This function does not handle prepositional verb phrases,
+// If no base morph is found, assumes the original word is the base.
 func (wn *WN) Morph(origword string, partOfSpeech int) string {
     partOfSpeechIndex := getPosIndex(partOfSpeech)
     if partOfSpeechIndex < 0  {
@@ -99,43 +102,51 @@ func (wn *WN) Morph(origword string, partOfSpeech int) string {
     if partOfSpeech == POS_ADVERB {
         // only use the exception lists for adverbs
         return origword
-    } else {
-        // replace the suffxes
-        if partOfSpeech == POS_NOUN {
-            if strings.HasSuffix(origword, "ful") {
-                origword = origword[:len(origword) - 3]
-            } else {
-                if strings.HasSuffix(origword, "ss") || len(origword) <= 2 {
-                    // too small
-                    return origword
-                }
-            }
-        }
-
-        for i := 1; i <= 4; i++ {
-            suffixIndex := len(origword) - i
-
-            if suffixIndex <= 0 {
-                break;
-            }
-
-            baseword := origword[:suffixIndex]
-            suffix := origword[suffixIndex:]
-            replacements, found := suffixReplacements[partOfSpeechIndex][suffix]
-            if found {
-                for _, replacement := range replacements {
-                    possibleLemma := baseword + replacement
-                    resp := wn.Lookup(possibleLemma)
-                    if len(resp) > 0 {
-                        // found it!
-                        return possibleLemma
-                    }
-                }
-            }
-        }
-
-        return origword
     }
+
+    if partOfSpeech != POS_VERB {
+        // check the original
+        resp := wn.Lookup(origword)
+        if len(resp) > 0 {
+            return origword
+        }
+    }
+
+    if partOfSpeech == POS_NOUN {
+        // if it's a noun, drop the -full or -ss suffixes
+        if strings.HasSuffix(origword, "ful") {
+            origword = origword[:len(origword) - 3]
+        } else {
+            if strings.HasSuffix(origword, "ss") || len(origword) <= 2 {
+                // too small
+                return origword
+            }
+        }
+    }
+
+    for i := 1; i <= 4; i++ {
+        suffixIndex := len(origword) - i
+        if suffixIndex <= 0 {
+            break;
+        }
+
+        baseword := origword[:suffixIndex]
+        suffix := origword[suffixIndex:]
+        replacements, found := suffixReplacements[partOfSpeechIndex][suffix]
+        if found {
+            for _, replacement := range replacements {
+                possibleLemma := baseword + replacement
+                resp := wn.Lookup(possibleLemma)
+                if len(resp) > 0 {
+                    // found it!
+                    return possibleLemma
+                }
+            }
+        }
+    }
+
+    // failed
+    return origword
 }
 
 func getPosIndex(pos int) int {


### PR DESCRIPTION
When lemmatizing, check if the original word is in WordNet if it's not in the exception list, before applying rules. This fixes nouns that end in 's', that are not in the exception list. Most notably, "the remains".

Also, moved the exception lists into the WN struct, because reasons. Well I guess the main reason is that I wanted InitMorphData() to be on the WN struct for consistency, and this gave it something to do.

```
jkoren@jonathans-ozlo-laptop:~/devel/go/src/github.com/ozlo/gown$ go test
PASS
ok      github.com/ozlo/gown    2.791s
```
