### PR TITLE
add back pointer to synsets

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -13,15 +13,42 @@ func main() {
 		return
 	}
 
-	printLookup(wn, "live")
-	printLookupWithPartOfSpeech(wn, "computer", gown.POS_NOUN)
+	//printLookup(wn, "live")
+	//printLookupWithPartOfSpeech(wn, "computer", gown.POS_NOUN)
+	//printLookupWithPartOfSpeechAndSense(wn, "lemma", gown.POS_NOUN, 1)
+	//printLookupSensesWithPartOfSpeech(wn, "lemma", gown.POS_NOUN)
+	words := []string { "computer", "computing machine", "computing device", "data processor", "electronic computer", "information processing system" }
+	for _, word := range words {
+		printSenseIndexEntryAndSynset(wn, word, gown.POS_NOUN, 1)
+	}
+}
+
+func printSenseIndexEntryAndSynset(wn *gown.WN, word string, pos int, senseId int) {
+	senseIndexEntry := wn.LookupWithPartOfSpeechAndSense(word, pos, senseId)
+	printSenseIndexEntry(wn, senseIndexEntry)
+	//printSynsetPtr(wn, senseIndexEntry.GetSynsetPtr())
+}
+
+func printLookupSensesWithPartOfSpeech(wn *gown.WN, word string, pos int) {
+	fmt.Printf("\n===================\n\n")
+	fmt.Printf("Lookup %q\n", word)
+	for _, senseIndexEntry := range wn.LookupSensesWithPartOfSpeech(word, pos) {
+		printSenseIndexEntry(wn, senseIndexEntry)
+		fmt.Printf("\n")
+	}
+}
+
+
+func printLookupWithPartOfSpeechAndSense(wn *gown.WN, word string, pos int, senseId int) {
+	senseIndexEntry := wn.LookupWithPartOfSpeechAndSense(word, pos, senseId)
+	printSenseIndexEntry(wn, senseIndexEntry)
 }
 
 func printLookup(wn *gown.WN, word string) {
 	fmt.Printf("\n===================\n\n")
 	fmt.Printf("Lookup %q\n", word)
-	for resultId, senseIndexEntry := range wn.Lookup(word) {
-		printSenseIndexEntry(wn, resultId, senseIndexEntry)
+	for _, senseIndexEntry := range wn.Lookup(word) {
+		printSenseIndexEntry(wn, senseIndexEntry)
 		fmt.Printf("\n")
 	}
 }
@@ -42,16 +69,18 @@ func printLookupWithPartOfSpeech(wn *gown.WN, word string, pos int) {
 	}
 }
 
-func printSenseIndexEntry(wn *gown.WN, resultId int, senseIndexEntry *gown.SenseIndexEntry) {
-	fmt.Printf("\tresultId: %2d POS: (%d) %s TagCount: %d synsetOffset: %d\n",
-		resultId,
+func printSenseIndexEntry(wn *gown.WN, senseIndexEntry *gown.SenseIndexEntry) {
+	fmt.Printf("\t%s\n", senseIndexEntry.ToString())
+	/*
+	fmt.Printf("\tLexId: %d  POS: (%d) %s SenseNumber: %d TagCount: %d synsetOffset: %d\n",
+		senseIndexEntry.LexId,
 		senseIndexEntry.PartOfSpeech,
 		gown.PART_OF_SPEECH_ID_TO_STRING[senseIndexEntry.PartOfSpeech],
+		senseIndexEntry.SenseNumber,
 		senseIndexEntry.TagCount,
 		senseIndexEntry.SynsetOffset,
 	)
-	synsetPtr := wn.GetSynset(senseIndexEntry.PartOfSpeech, senseIndexEntry.SynsetOffset)
-	printSynsetPtr(wn, synsetPtr)
+	*/
 }
 
 func printSynsetPtr(wn *gown.WN, synsetPtr *gown.Synset) {
@@ -106,7 +135,7 @@ func printRelationship(wn *gown.WN, i int, relation gown.RelationshipEdge, srcWo
 			relation.TargetWordNumber,
 			targetWordNumber,
 			targetPtr.Words[targetWordNumber], star,
-			
+
 			relation)
 	} else {
 		fmt.Printf("NIL RELATION\n")

--- a/sense_index_test.go
+++ b/sense_index_test.go
@@ -7,7 +7,7 @@ import (
 func TestLoadSenseIndex(t *testing.T) {
     dictDir, _ := GetWordNetDictDir()
     senseIndexFile := dictDir + "/index.sense"
-    senseIndex, err := loadSenseIndex(senseIndexFile)
+    senseIndex, err := loadSenseIndex(nil, senseIndexFile)
     if senseIndex == nil {
         t.Fatalf("Failed to load sense index: %v", err)
     }
@@ -18,7 +18,7 @@ func TestLoadSenseIndex(t *testing.T) {
     computer: {1  6 0 0 3086983 1 6} { NOUN, file: noun.artifact, lex_id: 0 head: , head_id: 0, synset_offset: 3086983, sense_number: 1, tag_cnt: 6 }
     computer: {1 18 0 0 9906486 2 0} { NOUN, file: noun.person,   lex_id: 0 head: , head_id: 0, synset_offset: 9906486, sense_number: 2, tag_cnt: 0 }
     */
-    computerLemmas, _ := (*senseIndex)["computer"]
+    computerLemmas, _ := senseIndex["computer"]
     if computerLemmas == nil || len(computerLemmas) == 0 {
         t.Fatalf("\"computer\" not found in sense index. Not loaded correctly?")
     }
@@ -65,7 +65,7 @@ func TestLoadSenseIndex(t *testing.T) {
     live%5:00:02:current:00 00670686 8 0
     live%5:00:07:active:05 00041710 11 0
     */
-    liveLemmas, _ := (*senseIndex)["live"]
+    liveLemmas, _ := senseIndex["live"]
     if liveLemmas == nil || len(liveLemmas) == 0 {
         t.Fatalf("\"live\" not found in sense index. Not loaded correctly?")
     }
@@ -100,7 +100,7 @@ func TestLoadSenseIndex(t *testing.T) {
     /*
     02408581 05 n 03 Aberdeen_Angus 0 Angus 0 black_Angus 0 001 @ 02406838 n 0000 | black hornless breed from Scotland
     */
-    angusLemmas, _ := (*senseIndex)["angus"]
+    angusLemmas, _ := senseIndex["angus"]
     t.Logf("angusLemmas = %v\n", angusLemmas)
     if angusLemmas == nil || len(angusLemmas) == 0 {
         t.Fatalf("\"angus\" not found in sense index. Not loaded correctly?")


### PR DESCRIPTION
Add back pointer from `SenseIndexEntry` to `Synset`
Make `SenseIndex` no longer a pointer
Make `Iter()` spit out `*Synset` instead of real `Synset`
Add `iterSenses()`