### PR TITLE
everything returns pointers

### DIFF
--- a/data_file.go
+++ b/data_file.go
@@ -41,7 +41,7 @@ type DataIndexEntry struct {
     SynsetOffsets []int
 }
 
-type dataFile map[int]Synset
+type dataFile map[int]*Synset
 type Synset struct {
     SynsetOffset int
     LexographerFilenum int
@@ -80,7 +80,7 @@ func DataIndexIterator(di *dataIndex) <-chan DataIndexPair {
 // Reads a index.POS (e.g. index.noun, index.verb, etc.) file and populates
 // a dataIndex . The index format is:
 // lemma  pos  synset_cnt  p_cnt  [ptr_symbol...]  sense_cnt  tagsense_cnt   synset_offset  [synset_offset...]
-func readPosIndex(posIndexFilename string) (*dataIndex, error) {
+func readPosIndex(posIndexFilename string) (dataIndex, error) {
     index := dataIndex{}
 
     infile, err := os.Open(posIndexFilename)
@@ -141,13 +141,13 @@ func readPosIndex(posIndexFilename string) (*dataIndex, error) {
         }
     }
 
-    return &index, nil
+    return index, nil
 }
 
 // Reads a data.POS (e.g. data.noun, data.verb, etc.) file and populates
 // a map of ints to dataIndexEntries. The data format is:
 // synset_offset  lex_filenum  ss_type  w_cnt  word  lex_id  [word  lex_id...]  p_cnt  [ptr...]  [frames...]  |   gloss
-func readPosData(posDataFilename string) (*dataFile, error) {
+func readPosData(posDataFilename string) (dataFile, error) {
     data := dataFile{}
 
     infile, err := os.Open(posDataFilename)
@@ -227,7 +227,7 @@ func readPosData(posDataFilename string) (*dataFile, error) {
             gloss = ""
         }
 
-        data[synset_offset] = Synset {
+        data[synset_offset] = &Synset {
                 SynsetOffset: synset_offset,
                 LexographerFilenum: lex_filenum,
                 PartOfSpeech: ss_type,
@@ -238,5 +238,5 @@ func readPosData(posDataFilename string) (*dataFile, error) {
         }
     }
 
-    return &data, nil
+    return data, nil
 }

--- a/data_file.go
+++ b/data_file.go
@@ -34,26 +34,26 @@ another via the synset_offset s.
 
 type dataIndex map[string]DataIndexEntry
 type DataIndexEntry struct {
-    partOfSpeech int
-    synsetCount int
-    relationships []int
-    tagSenseCount int
-    synsetOffsets []int
+    PartOfSpeech int
+    SynsetCount int
+    Relationships []int
+    TagSenseCount int
+    SynsetOffsets []int
 }
 func (die *DataIndexEntry) GetPartOfSpeech() int {
-    return die.partOfSpeech
+    return die.PartOfSpeech
 }
 func (die *DataIndexEntry) GetSynsetCount() int {
-    return die.synsetCount
+    return die.SynsetCount
 }
 func (die *DataIndexEntry) GetRelationships() []int {
-    return copyIntArray(die.relationships)
+    return copyIntArray(die.Relationships)
 }
 func (die *DataIndexEntry) GetTagSenseCount() int {
-    return die.tagSenseCount
+    return die.TagSenseCount
 }
 func (die *DataIndexEntry) GetSynsetOffsets() []int {
-    return copyIntArray(die.synsetOffsets)
+    return copyIntArray(die.SynsetOffsets)
 }
 
 type dataFile map[int]*Synset
@@ -174,11 +174,11 @@ func readPosIndex(posIndexFilename string) (dataIndex, error) {
             fmt.Printf("WARNING: %s already exists. Overwriting.\n", lemma)
         }
         index[lemma] = DataIndexEntry {
-            partOfSpeech: pos_tag,
-            synsetCount: synset_cnt,
-            relationships: relationships,
-            tagSenseCount: tagsense_cnt,
-            synsetOffsets: synsetOffsets,
+            PartOfSpeech: pos_tag,
+            SynsetCount: synset_cnt,
+            Relationships: relationships,
+            TagSenseCount: tagsense_cnt,
+            SynsetOffsets: synsetOffsets,
         }
     }
 

--- a/data_file.go
+++ b/data_file.go
@@ -34,26 +34,26 @@ another via the synset_offset s.
 
 type dataIndex map[string]DataIndexEntry
 type DataIndexEntry struct {
-    PartOfSpeech int
-    SynsetCount int
-    Relationships []int
-    TagSenseCount int
-    SynsetOffsets []int
+    partOfSpeech int
+    synsetCount int
+    relationships []int
+    tagSenseCount int
+    synsetOffsets []int
 }
 func (die *DataIndexEntry) GetPartOfSpeech() int {
-    return die.PartOfSpeech
+    return die.partOfSpeech
 }
 func (die *DataIndexEntry) GetSynsetCount() int {
-    return die.SynsetCount
+    return die.synsetCount
 }
 func (die *DataIndexEntry) GetRelationships() []int {
-    return copyIntArray(die.Relationships)
+    return copyIntArray(die.relationships)
 }
 func (die *DataIndexEntry) GetTagSenseCount() int {
-    return die.TagSenseCount
+    return die.tagSenseCount
 }
 func (die *DataIndexEntry) GetSynsetOffsets() []int {
-    return copyIntArray(die.SynsetOffsets)
+    return copyIntArray(die.synsetOffsets)
 }
 
 type dataFile map[int]*Synset
@@ -174,11 +174,11 @@ func readPosIndex(posIndexFilename string) (dataIndex, error) {
             fmt.Printf("WARNING: %s already exists. Overwriting.\n", lemma)
         }
         index[lemma] = DataIndexEntry {
-            PartOfSpeech: pos_tag,
-            SynsetCount: synset_cnt,
-            Relationships: relationships,
-            TagSenseCount: tagsense_cnt,
-            SynsetOffsets: synsetOffsets,
+            partOfSpeech: pos_tag,
+            synsetCount: synset_cnt,
+            relationships: relationships,
+            tagSenseCount: tagsense_cnt,
+            synsetOffsets: synsetOffsets,
         }
     }
 

--- a/data_file.go
+++ b/data_file.go
@@ -34,47 +34,88 @@ another via the synset_offset s.
 
 type dataIndex map[string]DataIndexEntry
 type DataIndexEntry struct {
-    PartOfSpeech int
-    SynsetCount int
-    Relationships []int
-    TagSenseCount int
-    SynsetOffsets []int
+    partOfSpeech int
+    synsetCount int
+    relationships []int
+    tagSenseCount int
+    synsetOffsets []int
+}
+func (die *DataIndexEntry) GetPartOfSpeech() int {
+    return die.partOfSpeech
+}
+func (die *DataIndexEntry) GetSynsetCount() int {
+    return die.synsetCount
+}
+func (die *DataIndexEntry) GetRelationships() []int {
+    return copyIntArray(die.relationships)
+}
+func (die *DataIndexEntry) GetTagSenseCount() int {
+    return die.tagSenseCount
+}
+func (die *DataIndexEntry) GetSynsetOffsets() []int {
+    return copyIntArray(die.synsetOffsets)
 }
 
 type dataFile map[int]*Synset
 type Synset struct {
-    SynsetOffset int
-    LexographerFilenum int
-    PartOfSpeech int
-    Words []string
-    LexIds []int
-    Relationships []RelationshipEdge
-    Gloss string
+    synsetOffset int
+    lexographerFilenum int
+    partOfSpeech int
+    words []string
+    lexIds []int
+    relationships []RelationshipEdge
+    gloss string
 }
-type RelationshipEdge struct {
-    RelationshipType int      // ANTONYM_RELATIONSHIP, etc.
-    SynsetOffset int          // synset offset of the target
-    PartOfSpeech int          // part-of-speech of target
-    SourceWordNumber int      // word number of the source
-    TargetWordNumber int      // word number of the target
+func (s *Synset) GetSynsetOffset() int {
+    return s.synsetOffset
+}
+func (s *Synset) GetLexographerFilenum() int {
+    return s.lexographerFilenum
+}
+func (s *Synset) GetLexographerFilename() string {
+    return cLexographerFileNumToName[s.lexographerFilenum]
+}
+func (s *Synset) GetPartOfSpeech() int {
+    return s.partOfSpeech
+}
+func (s *Synset) GetWords() []string {
+    return copyStringArray(s.words)
+}
+func (s *Synset) GetLexIds() []int {
+    return copyIntArray(s.lexIds)
+}
+func (s *Synset) GetRelationships() []RelationshipEdge {
+    ret := make([]RelationshipEdge, len(s.relationships))
+    for i, e := range s.relationships {
+        ret[i] = e
+    }
+    return ret
+}
+func (s *Synset) GetGloss() string {
+    return s.gloss
 }
 
-type DataIndexPair struct {
-    Lexeme string
-    IndexEntry DataIndexEntry
+type RelationshipEdge struct {
+    relationshipType int      // ANTONYM_RELATIONSHIP, etc.
+    synsetOffset int          // synset offset of the target
+    partOfSpeech int          // part-of-speech of target
+    sourceWordNumber int      // word number of the source
+    targetWordNumber int      // word number of the target
 }
-func DataIndexIterator(di *dataIndex) <-chan DataIndexPair {
-    ch := make(chan DataIndexPair)
-    go func() {
-        for k, v := range *di {
-            ch <- DataIndexPair {
-                Lexeme: k,
-                IndexEntry: v,
-            }
-        }
-        close(ch) // Remember to close or the loop never ends!
-    }()
-    return ch
+func (re *RelationshipEdge) GetRelationshipType() int {
+    return re.relationshipType
+}
+func (re *RelationshipEdge) GetSynsetOffset() int {
+    return re.synsetOffset
+}
+func (re *RelationshipEdge) GetPartOfSpeech() int {
+    return re.partOfSpeech
+}
+func (re *RelationshipEdge) GetSourceWordNumber() int {
+    return re.sourceWordNumber
+}
+func (re *RelationshipEdge) GetTargetWordNumber() int {
+    return re.targetWordNumber
 }
 
 // Reads a index.POS (e.g. index.noun, index.verb, etc.) file and populates
@@ -116,7 +157,7 @@ func readPosIndex(posIndexFilename string) (dataIndex, error) {
         relationships := make([]int, p_cnt)
         // consume p_cnt pointer symbols
         for i := 0; i < p_cnt; i++ {
-            relationships[i], _ = RELATIONSHIP_POINTER_SYMBOLS[fields[field_index]]
+            relationships[i], _ = cRelationshipPointerSymbols[fields[field_index]]
             field_index++
         }
         field_index++  // sense_cnt is redundant with synset_cnt, so skip it
@@ -133,11 +174,11 @@ func readPosIndex(posIndexFilename string) (dataIndex, error) {
             fmt.Printf("WARNING: %s already exists. Overwriting.\n", lemma)
         }
         index[lemma] = DataIndexEntry {
-            PartOfSpeech: pos_tag,
-            SynsetCount: synset_cnt,
-            Relationships: relationships,
-            TagSenseCount: tagsense_cnt,
-            SynsetOffsets: synsetOffsets,
+            partOfSpeech: pos_tag,
+            synsetCount: synset_cnt,
+            relationships: relationships,
+            tagSenseCount: tagsense_cnt,
+            synsetOffsets: synsetOffsets,
         }
     }
 
@@ -194,7 +235,7 @@ func readPosData(posDataFilename string) (dataFile, error) {
         fieldIndex++
         pointers := make([]RelationshipEdge, p_cnt)
         for i := 0; i < p_cnt; i++ {
-            pointer_type, symbolFound := RELATIONSHIP_POINTER_SYMBOLS[fields[fieldIndex]]
+            pointer_type, symbolFound := cRelationshipPointerSymbols[fields[fieldIndex]]
             if !symbolFound {
                 panic(fmt.Sprintf("could not handle relationship symbol %s in line <<%v>>, file %s", fields[fieldIndex], line, posDataFilename))
             }
@@ -210,11 +251,11 @@ func readPosData(posDataFilename string) (dataFile, error) {
             src_word_num := int(src_wordnum64)
             dest_word_num := int(dest_wordnum64)
             pointers[i] = RelationshipEdge {
-                RelationshipType: pointer_type,
-                SynsetOffset: synset_offset,
-                PartOfSpeech: pos,
-                SourceWordNumber: src_word_num,
-                TargetWordNumber: dest_word_num,
+                relationshipType: pointer_type,
+                synsetOffset: synset_offset,
+                partOfSpeech: pos,
+                sourceWordNumber: src_word_num,
+                targetWordNumber: dest_word_num,
             }
         }
         // skip data.verb frames
@@ -228,13 +269,13 @@ func readPosData(posDataFilename string) (dataFile, error) {
         }
 
         data[synset_offset] = &Synset {
-                SynsetOffset: synset_offset,
-                LexographerFilenum: lex_filenum,
-                PartOfSpeech: ss_type,
-                Words: words,
-                LexIds: lex_ids,
-                Relationships: pointers,
-                Gloss: gloss,
+                synsetOffset: synset_offset,
+                lexographerFilenum: lex_filenum,
+                partOfSpeech: ss_type,
+                words: words,
+                lexIds: lex_ids,
+                relationships: pointers,
+                gloss: gloss,
         }
     }
 

--- a/example/example.go
+++ b/example/example.go
@@ -30,7 +30,7 @@ func main() {
 func printSenseIndexEntryAndSynset(wn *gown.WN, word string, pos int, senseId int) {
 	senseIndexEntry := wn.LookupWithPartOfSpeechAndSense(word, pos, senseId)
 	printSenseIndexEntry(wn, senseIndexEntry)
-	printSynsetPtr(wn, senseIndexEntry.SynsetPtr)
+	printSynsetPtr(wn, senseIndexEntry.GetSynsetPtr())
 }
 
 func printLookupSensesWithPartOfSpeech(wn *gown.WN, word string, pos int) {
@@ -61,11 +61,11 @@ func printLookupWithPartOfSpeech(wn *gown.WN, word string, pos int) {
 	fmt.Printf("LookupWithPartOfSpeech %q %d\n", word, pos)
 	dataIndexEntry := wn.LookupWithPartOfSpeech(word, pos)
 	if dataIndexEntry == nil {
-		fmt.Printf("Can't found a \"%s\" as a %s!\n", word, gown.PART_OF_SPEECH_ID_TO_STRING[pos])
+		fmt.Printf("Can't found a \"%s\" as a %s!\n", word, gown.PartOfSpeechToString(pos))
 	} else {
-		fmt.Printf("%s (%s)\n", word, gown.PART_OF_SPEECH_ID_TO_STRING[pos])
+		fmt.Printf("%s (%s)\n", word, gown.PartOfSpeechToString(pos))
 		fmt.Printf("%v\n", *dataIndexEntry)
-		for _, synsetOffset := range dataIndexEntry.SynsetOffsets {
+		for _, synsetOffset := range dataIndexEntry.GetSynsetOffsets() {
 			printSynsetPtr(wn, wn.GetSynset(pos, synsetOffset))
 			fmt.Printf("\n")
 		}
@@ -80,54 +80,54 @@ func printSynsetPtr(wn *gown.WN, synsetPtr *gown.Synset) {
 	if synsetPtr == nil {
 		fmt.Printf("\tNO SYNSET!\n")
 	} else {
-		fmt.Printf("\tGloss: %s\n", synsetPtr.Gloss)
+		fmt.Printf("\tGloss: %s\n", synsetPtr.GetGloss())
 		fmt.Printf("\tLexFile: %s POS: %s\n",
-			gown.LEXOGRAPHER_FILE_NUM_TO_NAME[synsetPtr.LexographerFilenum],
-			gown.PART_OF_SPEECH_ID_TO_STRING[synsetPtr.PartOfSpeech])
+			synsetPtr.GetLexographerFilename(),
+			gown.PartOfSpeechToString(synsetPtr.GetPartOfSpeech()))
 
 		fmt.Printf("\twords:")
-		for i, word := range synsetPtr.Words {
-			fmt.Printf(" %s (%d)", word, synsetPtr.LexIds[i])
+		for i, word := range synsetPtr.GetWords() {
+			fmt.Printf(" %s (%d)", word, synsetPtr.GetLexIds()[i])
 		}
 		fmt.Printf("\n")
 
 		fmt.Printf("\trelations:\n")
-		for i, relation := range synsetPtr.Relationships {
-			printRelationship(wn, i, relation, synsetPtr.Words)
+		for i, relation := range synsetPtr.GetRelationships() {
+			printRelationship(wn, i, relation, synsetPtr.GetWords())
 		}
 	}
 }
 
 func printRelationship(wn *gown.WN, i int, relation gown.RelationshipEdge, srcWords []string) {
-	fmt.Printf("\t\t%d: %s (%d) >> ", i, gown.RELATIONSHIP_ID_TO_STRING[relation.RelationshipType], relation.RelationshipType)
-	targetPtr := wn.GetSynset(relation.PartOfSpeech, relation.SynsetOffset)
+	fmt.Printf("\t\t%d: %s (%d) >> ", i, gown.RelationshipIdToString(relation.GetRelationshipType()), relation.GetRelationshipType())
+	targetPtr := wn.GetSynset(relation.GetPartOfSpeech(), relation.GetSynsetOffset())
 	if targetPtr != nil {
-		srcWordNumber := relation.SourceWordNumber
+		srcWordNumber := relation.GetSourceWordNumber()
 		if srcWordNumber > 0 {
 			srcWordNumber-- // make it zero based
 		}
-		targetWordNumber := relation.TargetWordNumber
+		targetWordNumber := relation.GetTargetWordNumber()
 		if targetWordNumber > 0 {
 			targetWordNumber-- // make it zero based
 		}
 
 		star := ""
-		if relation.SourceWordNumber == 0 && relation.TargetWordNumber == 0 {
+		if relation.GetSourceWordNumber() == 0 && relation.GetTargetWordNumber() == 0 {
 			star = "*"
 		}
 
 		fmt.Printf("%s (%d) %v  (%d:%d:%s%s -> %d:%d:%s%s) {{%v}}\n",
-			gown.PART_OF_SPEECH_ID_TO_STRING[relation.PartOfSpeech],
-			relation.SynsetOffset,
-			targetPtr.Words,
+			gown.PartOfSpeechToString(relation.GetPartOfSpeech()),
+			relation.GetSynsetOffset(),
+			targetPtr.GetWords(),
 
-			relation.SourceWordNumber,
+			relation.GetSourceWordNumber(),
 			srcWordNumber,
 			srcWords[srcWordNumber], star,
 
-			relation.TargetWordNumber,
+			relation.GetTargetWordNumber(),
 			targetWordNumber,
-			targetPtr.Words[targetWordNumber], star,
+			targetPtr.GetWords()[targetWordNumber], star,
 
 			relation)
 	} else {

--- a/example/example.go
+++ b/example/example.go
@@ -30,7 +30,7 @@ func main() {
 func printSenseIndexEntryAndSynset(wn *gown.WN, word string, pos int, senseId int) {
 	senseIndexEntry := wn.LookupWithPartOfSpeechAndSense(word, pos, senseId)
 	printSenseIndexEntry(wn, senseIndexEntry)
-	printSynsetPtr(wn, senseIndexEntry.GetSynsetPtr())
+	printSynsetPtr(wn, senseIndexEntry.SynsetPtr)
 }
 
 func printLookupSensesWithPartOfSpeech(wn *gown.WN, word string, pos int) {

--- a/gown.go
+++ b/gown.go
@@ -8,8 +8,8 @@ import (
 
 type WN struct {
 	senseIndex  senseIndex
-	PosIndicies map[int]*dataIndex
-	posData     map[int]*dataFile
+	PosIndicies map[int]dataIndex
+	posData     map[int]dataFile
 	exceptions  []map[string]string
 }
 
@@ -55,8 +55,8 @@ func GetWordNetDictDir() (string, error) {
 func LoadWordNet(dictDirname string) (*WN, error) {
 	wn := &WN{
 		senseIndex:  nil,
-		PosIndicies: map[int]*dataIndex{},
-		posData:     map[int]*dataFile{},
+		PosIndicies: map[int]dataIndex{},
+		posData:     map[int]dataFile{},
 	}
 
 	var err error = nil
@@ -85,7 +85,7 @@ func (wn *WN) LookupWithPartOfSpeech(lemma string, pos int) *DataIndexEntry {
 	if !exists {
 		return nil
 	}
-	sn, exists := (*posIndexPtr)[strings.ToLower(lemma)]
+	sn, exists := posIndexPtr[strings.ToLower(lemma)]
 	if exists {
 		return &sn
 	} else {
@@ -98,7 +98,7 @@ func (wn *WN) LookupSensesWithPartOfSpeech(lemma string, pos int) []*SenseIndexE
 	ret := make([]*SenseIndexEntry, 0, len(senses))
 	for i, _ := range senses {
 		if senses[i].PartOfSpeech == pos {
-			ret = append(ret, &senses[i])
+			ret = append(ret, senses[i])
 		}
 	}
 	return ret
@@ -108,22 +108,15 @@ func (wn *WN) LookupWithPartOfSpeechAndSense(lemma string, pos int, senseId int)
 	senses, _ := wn.senseIndex[lemma]
 	for _, sense := range senses {
 		if (sense.PartOfSpeech == pos) && (sense.SenseNumber == senseId) {
-			return &sense
+			return sense
 		}
 	}
 	return nil
 }
 
 func (wn *WN) Lookup(lemma string) []*SenseIndexEntry {
-	senseEntries, exists := wn.senseIndex[strings.ToLower(lemma)]
-	if !exists {
-		return []*SenseIndexEntry{}
-	}
-	ret := make([]*SenseIndexEntry, len(senseEntries))
-	for i, _ := range senseEntries {
-		ret[i] = &senseEntries[i]
-	}
-	return ret
+	senseEntries, _ := wn.senseIndex[strings.ToLower(lemma)]
+	return senseEntries
 }
 
 func (wn *WN) GetSynset(pos int, synsetOffset int) *Synset {
@@ -134,11 +127,8 @@ func (wn *WN) GetSynset(pos int, synsetOffset int) *Synset {
 	if !exists || idxPtr == nil {
 		return nil
 	}
-	s, exists := (*idxPtr)[synsetOffset]
-	if !exists {
-		return nil
-	}
-	return &s
+	s, _ := idxPtr[synsetOffset]
+	return s
 }
 
 func (wn *WN) TraverseDataIndex(pos int) <-chan DataIndexPair {
@@ -148,7 +138,7 @@ func (wn *WN) TraverseDataIndex(pos int) <-chan DataIndexPair {
 	}
 	out := make(chan DataIndexPair)
 	go func() {
-		for k, v := range *table {
+		for k, v := range table {
 			out <- DataIndexPair{k, v}
 		}
 		close(out)
@@ -160,28 +150,8 @@ func (wn *WN) Iter() <-chan *Synset {
 	outChan := make(chan *Synset)
 	go func() {
 		for _, datFile := range wn.posData {
-			for _, synset := range *datFile {
-				words := make([]string, len(synset.Words))
-				for i, w := range synset.Words {
-					words[i] = w
-				}
-				lexids := make([]int, len(synset.LexIds))
-				for i, w := range synset.LexIds {
-					lexids[i] = w
-				}
-				edges := make([]RelationshipEdge, len(synset.Relationships))
-				for i, w := range synset.Relationships {
-					edges[i] = w
-				}
-				outChan <- &Synset{
-					SynsetOffset:       synset.SynsetOffset,
-					LexographerFilenum: synset.LexographerFilenum,
-					PartOfSpeech:       synset.PartOfSpeech,
-					Words:              words,
-					LexIds:             lexids,
-					Relationships:      edges,
-					Gloss:              synset.Gloss,
-				}
+			for _, synset := range datFile {
+				outChan <- synset
 			}
 		}
 		close(outChan)
@@ -193,8 +163,8 @@ func (wn *WN) IterSenses() <-chan *SenseIndexEntry {
 	outchan := make(chan *SenseIndexEntry)
 	go func() {
 		for _, senses := range wn.senseIndex {
-			for i, _ := range senses {
-				outchan <- &senses[i]
+			for _, sense := range senses {
+				outchan <- sense
 			}
 		}
 		close(outchan)

--- a/gown.go
+++ b/gown.go
@@ -97,7 +97,7 @@ func (wn *WN) LookupSensesWithPartOfSpeech(lemma string, pos int) []*SenseIndexE
 	senses, _ := wn.senseIndex[lemma]
 	ret := make([]*SenseIndexEntry, 0, len(senses))
 	for i, _ := range senses {
-		if senses[i].PartOfSpeech == pos {
+		if senses[i].partOfSpeech == pos {
 			ret = append(ret, senses[i])
 		}
 	}
@@ -107,7 +107,7 @@ func (wn *WN) LookupSensesWithPartOfSpeech(lemma string, pos int) []*SenseIndexE
 func (wn *WN) LookupWithPartOfSpeechAndSense(lemma string, pos int, senseId int) *SenseIndexEntry {
 	senses, _ := wn.senseIndex[lemma]
 	for _, sense := range senses {
-		if (sense.PartOfSpeech == pos) && (sense.SenseNumber == senseId) {
+		if (sense.partOfSpeech == pos) && (sense.senseNumber == senseId) {
 			return sense
 		}
 	}

--- a/gown.go
+++ b/gown.go
@@ -8,7 +8,7 @@ import (
 
 type WN struct {
 	senseIndex  senseIndex
-	PosIndicies map[int]dataIndex
+	posIndicies map[int]dataIndex
 	posData     map[int]dataFile
 	exceptions  []map[string]string
 }
@@ -55,14 +55,14 @@ func GetWordNetDictDir() (string, error) {
 func LoadWordNet(dictDirname string) (*WN, error) {
 	wn := &WN{
 		senseIndex:  nil,
-		PosIndicies: map[int]dataIndex{},
+		posIndicies: map[int]dataIndex{},
 		posData:     map[int]dataFile{},
 	}
 
 	var err error = nil
 	pos_file_names := []string{"", "noun", "verb", "adj", "adv"}
 	for i := 1; i < len(pos_file_names); i++ {
-		wn.PosIndicies[i], err = readPosIndex(dictDirname + "/index." + pos_file_names[i])
+		wn.posIndicies[i], err = readPosIndex(dictDirname + "/index." + pos_file_names[i])
 		if err != nil {
 			return nil, err
 		}
@@ -81,7 +81,7 @@ func LoadWordNet(dictDirname string) (*WN, error) {
 }
 
 func (wn *WN) LookupWithPartOfSpeech(lemma string, pos int) *DataIndexEntry {
-	posIndexPtr, exists := wn.PosIndicies[pos]
+	posIndexPtr, exists := wn.posIndicies[pos]
 	if !exists {
 		return nil
 	}
@@ -97,7 +97,7 @@ func (wn *WN) LookupSensesWithPartOfSpeech(lemma string, pos int) []*SenseIndexE
 	senses, _ := wn.senseIndex[lemma]
 	ret := make([]*SenseIndexEntry, 0, len(senses))
 	for i, _ := range senses {
-		if senses[i].PartOfSpeech == pos {
+		if senses[i].partOfSpeech == pos {
 			ret = append(ret, senses[i])
 		}
 	}
@@ -107,7 +107,7 @@ func (wn *WN) LookupSensesWithPartOfSpeech(lemma string, pos int) []*SenseIndexE
 func (wn *WN) LookupWithPartOfSpeechAndSense(lemma string, pos int, senseId int) *SenseIndexEntry {
 	senses, _ := wn.senseIndex[lemma]
 	for _, sense := range senses {
-		if (sense.PartOfSpeech == pos) && (sense.SenseNumber == senseId) {
+		if (sense.partOfSpeech == pos) && (sense.senseNumber == senseId) {
 			return sense
 		}
 	}
@@ -129,21 +129,6 @@ func (wn *WN) GetSynset(pos int, synsetOffset int) *Synset {
 	}
 	s, _ := idxPtr[synsetOffset]
 	return s
-}
-
-func (wn *WN) TraverseDataIndex(pos int) <-chan DataIndexPair {
-	table, ok := wn.PosIndicies[pos]
-	if !ok {
-		return nil
-	}
-	out := make(chan DataIndexPair)
-	go func() {
-		for k, v := range table {
-			out <- DataIndexPair{k, v}
-		}
-		close(out)
-	}()
-	return out
 }
 
 func (wn *WN) Iter() <-chan *Synset {
@@ -170,4 +155,26 @@ func (wn *WN) IterSenses() <-chan *SenseIndexEntry {
 		close(outchan)
 	}()
 	return outchan
+}
+
+type DataIndexPair struct {
+    Lexeme string
+    IndexEntry *DataIndexEntry
+}
+func (wn *WN) IterDataIndex(pos int) <-chan DataIndexPair {
+	table, ok := wn.posIndicies[pos]
+	if !ok {
+		return nil
+	}
+	out := make(chan DataIndexPair)
+	go func() {
+		for k, v := range table {
+			out <- DataIndexPair {
+				Lexeme: k,
+				IndexEntry: &v,
+			}
+		}
+		close(out)
+	}()
+	return out
 }

--- a/gown.go
+++ b/gown.go
@@ -97,7 +97,7 @@ func (wn *WN) LookupSensesWithPartOfSpeech(lemma string, pos int) []*SenseIndexE
 	senses, _ := wn.senseIndex[lemma]
 	ret := make([]*SenseIndexEntry, 0, len(senses))
 	for i, _ := range senses {
-		if senses[i].partOfSpeech == pos {
+		if senses[i].PartOfSpeech == pos {
 			ret = append(ret, senses[i])
 		}
 	}
@@ -107,7 +107,7 @@ func (wn *WN) LookupSensesWithPartOfSpeech(lemma string, pos int) []*SenseIndexE
 func (wn *WN) LookupWithPartOfSpeechAndSense(lemma string, pos int, senseId int) *SenseIndexEntry {
 	senses, _ := wn.senseIndex[lemma]
 	for _, sense := range senses {
-		if (sense.partOfSpeech == pos) && (sense.senseNumber == senseId) {
+		if (sense.PartOfSpeech == pos) && (sense.SenseNumber == senseId) {
 			return sense
 		}
 	}

--- a/gown_test.go
+++ b/gown_test.go
@@ -125,7 +125,7 @@ func TestIterate(t *testing.T) {
     i := 0
     for synset := range wn.Iter() {
         if i < atLeast {
-            for _, _ = range synset.Words {
+            for _, _ = range synset.GetWords() {
                 i++
                 if i == atLeast {
                     break

--- a/sense_index.go
+++ b/sense_index.go
@@ -23,7 +23,7 @@ synset containing the sense, and the number of times it has been tagged in the
 semantic concordance texts.
 */
 
-type senseIndex map[string][]SenseIndexEntry
+type senseIndex map[string][]*SenseIndexEntry
 type SenseIndexEntry struct {
     Lemma string
     PartOfSpeech int       // POS tag. (e.g. POS_NOUN, ...)
@@ -35,7 +35,7 @@ type SenseIndexEntry struct {
     SynsetOffset int       // byte offset into <POS>.data file
     SenseNumber int        // sense number within the <POS>.data for the word
     TagCount int           // number of times the word was tagged in semantic concordance texts
-    synsetPtr *Synset      // back ponter to the underlying synset.
+    SynsetPtr *Synset      // back ponter to the underlying synset.
 }
 
 func (e *SenseIndexEntry) ToString() string {
@@ -65,10 +65,6 @@ func (e *SenseIndexEntry) ToString() string {
         e.Lemma,
         e.SenseNumber,
         e.TagCount)
-}
-
-func (e *SenseIndexEntry) GetSynsetPtr() *Synset {
-    return e.synsetPtr
 }
 
 func loadSenseIndex(wn *WN, senseIndexFilename string) (senseIndex, error) {
@@ -115,7 +111,7 @@ func loadSenseIndex(wn *WN, senseIndexFilename string) (senseIndex, error) {
             synsetPtr = wn.GetSynset(ss_type, synset_offset)
         }
 
-        newEntry := SenseIndexEntry {
+        newEntry := &SenseIndexEntry {
             lemma,
             ss_type,
             lex_filenum,
@@ -130,7 +126,7 @@ func loadSenseIndex(wn *WN, senseIndexFilename string) (senseIndex, error) {
 
         entries, exists := index[lemma]
         if !exists {
-            index[lemma] = make([]SenseIndexEntry, 1)
+            index[lemma] = make([]*SenseIndexEntry, 1)
             index[lemma][0] = newEntry
         } else {
             index[lemma] = append(entries, newEntry)

--- a/sense_index.go
+++ b/sense_index.go
@@ -25,22 +25,55 @@ semantic concordance texts.
 
 type senseIndex map[string][]*SenseIndexEntry
 type SenseIndexEntry struct {
-    Lemma string
-    PartOfSpeech int       // POS tag. (e.g. POS_NOUN, ...)
-    LexographerFilenum int // index into LEXOGRAPHER_FILE_NUM_TO_NAME
-    LexId int              // identifies a sense within a lemma file (default is 0)
-    HeadWord string        // OPTIONAL lemma of the first word of the adjective satellite's head synset. (PartOfSpeech of this entry is 5)
-    HeadId int             // OPTIONAL uniquely identifies head_word in a lexographer file. ( fmt.Sprintf("%s%2d", head_word, head_id) )
+    lemma string
+    partOfSpeech int       // POS tag. (e.g. POS_NOUN, ...)
+    lexographerFilenum int // index into cLexographerFileNumToName
+    lexId int              // identifies a sense within a lemma file (default is 0)
+    headWord string        // OPTIONAL lemma of the first word of the adjective satellite's head synset. (PartOfSpeech of this entry is 5)
+    headId int             // OPTIONAL uniquely identifies head_word in a lexographer file. ( fmt.Sprintf("%s%2d", head_word, head_id) )
 
-    SynsetOffset int       // byte offset into <POS>.data file
-    SenseNumber int        // sense number within the <POS>.data for the word
-    TagCount int           // number of times the word was tagged in semantic concordance texts
-    SynsetPtr *Synset      // back ponter to the underlying synset.
+    synsetOffset int       // byte offset into <POS>.data file
+    senseNumber int        // sense number within the <POS>.data for the word
+    tagCount int           // number of times the word was tagged in semantic concordance texts
+    synsetPtr *Synset      // back ponter to the underlying synset.
+}
+func (sei *SenseIndexEntry) GetLemma() string {
+    return sei.lemma
+}
+func (sei *SenseIndexEntry) GetPartOfSpeech() int {
+    return sei.partOfSpeech
+}
+func (sei *SenseIndexEntry) GetLexographerFilenum() int {
+    return sei.lexographerFilenum
+}
+func (sei *SenseIndexEntry) GetLexographerFilename() string {
+    return cLexographerFileNumToName[sei.lexographerFilenum]
+}
+func (sei *SenseIndexEntry) GetLexId() int {
+    return sei.lexId
+}
+func (sei *SenseIndexEntry) GetHeadWord() string {
+    return sei.headWord
+}
+func (sei *SenseIndexEntry) GetHeadId() int {
+    return sei.headId
+}
+func (sei *SenseIndexEntry) GetSynsetOffset() int {
+    return sei.synsetOffset
+}
+func (sei *SenseIndexEntry) GetSenseNumber() int {
+    return sei.senseNumber
+}
+func (sei *SenseIndexEntry) GetTagCount() int {
+    return sei.tagCount
+}
+func (sei *SenseIndexEntry) GetSynsetPtr() *Synset {
+    return sei.synsetPtr
 }
 
 func (e *SenseIndexEntry) ToString() string {
     var pos_str string
-    switch(e.PartOfSpeech) {
+    switch(e.partOfSpeech) {
     case POS_UNSUPPORTED:
         pos_str = "UNSUPPORTED"
     case POS_NOUN:
@@ -57,14 +90,14 @@ func (e *SenseIndexEntry) ToString() string {
 
     return fmt.Sprintf("{ %s, file: %s, lex_id: %d head: %s, head_id: %d, synset_offset: %d, lemma %q sense_number: %d, tag_cnt: %d }",
         pos_str,
-        LEXOGRAPHER_FILE_NUM_TO_NAME[e.LexographerFilenum],
-        e.LexId,
-        e.HeadWord,
-        e.HeadId,
-        e.SynsetOffset,
-        e.Lemma,
-        e.SenseNumber,
-        e.TagCount)
+        cLexographerFileNumToName[e.lexographerFilenum],
+        e.lexId,
+        e.headWord,
+        e.headId,
+        e.synsetOffset,
+        e.lemma,
+        e.senseNumber,
+        e.tagCount)
 }
 
 func loadSenseIndex(wn *WN, senseIndexFilename string) (senseIndex, error) {
@@ -101,7 +134,7 @@ func loadSenseIndex(wn *WN, senseIndexFilename string) (senseIndex, error) {
         lemma := readStoredLemma(sense_key_fields[0])
         lex_sense_fields := strings.Split(sense_key_fields[1], ":")
         ss_type, _ := strconv.Atoi(lex_sense_fields[0])     // POS tag. (e.g. POS_NOUN, ...)
-        lex_filenum, _ := strconv.Atoi(lex_sense_fields[1]) // index into LEXOGRAPHER_FILE_NUM_TO_NAME
+        lex_filenum, _ := strconv.Atoi(lex_sense_fields[1]) // index into cLexographerFileNumToName
         lex_id, _ := strconv.Atoi(lex_sense_fields[2])      // identifies a sense within a lemma file (default is 0)
         head_word := lex_sense_fields[3]                    // OPTIONAL lemma of the first word of the adjective satellite's head synset. (ss_type of this entry is 5)
         head_id, _ := strconv.Atoi(lex_sense_fields[4])     // OPTIONAL uniquely identifies head_word in a lexographer file. ( fmt.Sprintf("%s%2d", head_word, head_id) )

--- a/sense_index.go
+++ b/sense_index.go
@@ -25,47 +25,47 @@ semantic concordance texts.
 
 type senseIndex map[string][]*SenseIndexEntry
 type SenseIndexEntry struct {
-    Lemma string
-    PartOfSpeech int       // POS tag. (e.g. POS_NOUN, ...)
-    LexographerFilenum int // index into cLexographerFileNumToName
-    LexId int              // identifies a sense within a lemma file (default is 0)
-    HeadWord string        // OPTIONAL lemma of the first word of the adjective satellite's head synset. (PartOfSpeech of this entry is 5)
-    HeadId int             // OPTIONAL uniquely identifies head_word in a lexographer file. ( fmt.Sprintf("%s%2d", head_word, head_id) )
+    lemma string
+    partOfSpeech int       // POS tag. (e.g. POS_NOUN, ...)
+    lexographerFilenum int // index into cLexographerFileNumToName
+    lexId int              // identifies a sense within a lemma file (default is 0)
+    headWord string        // OPTIONAL lemma of the first word of the adjective satellite's head synset. (PartOfSpeech of this entry is 5)
+    headId int             // OPTIONAL uniquely identifies head_word in a lexographer file. ( fmt.Sprintf("%s%2d", head_word, head_id) )
 
-    SynsetOffset int       // byte offset into <POS>.data file
-    SenseNumber int        // sense number within the <POS>.data for the word
-    TagCount int           // number of times the word was tagged in semantic concordance texts
+    synsetOffset int       // byte offset into <POS>.data file
+    senseNumber int        // sense number within the <POS>.data for the word
+    tagCount int           // number of times the word was tagged in semantic concordance texts
     synsetPtr *Synset      // back ponter to the underlying synset.
 }
 func (sei *SenseIndexEntry) GetLemma() string {
-    return sei.Lemma
+    return sei.lemma
 }
 func (sei *SenseIndexEntry) GetPartOfSpeech() int {
-    return sei.PartOfSpeech
+    return sei.partOfSpeech
 }
 func (sei *SenseIndexEntry) GetLexographerFilenum() int {
-    return sei.LexographerFilenum
+    return sei.lexographerFilenum
 }
 func (sei *SenseIndexEntry) GetLexographerFilename() string {
-    return cLexographerFileNumToName[sei.LexographerFilenum]
+    return cLexographerFileNumToName[sei.lexographerFilenum]
 }
 func (sei *SenseIndexEntry) GetLexId() int {
-    return sei.LexId
+    return sei.lexId
 }
 func (sei *SenseIndexEntry) GetHeadWord() string {
-    return sei.HeadWord
+    return sei.headWord
 }
 func (sei *SenseIndexEntry) GetHeadId() int {
-    return sei.HeadId
+    return sei.headId
 }
 func (sei *SenseIndexEntry) GetSynsetOffset() int {
-    return sei.SynsetOffset
+    return sei.synsetOffset
 }
 func (sei *SenseIndexEntry) GetSenseNumber() int {
-    return sei.SenseNumber
+    return sei.senseNumber
 }
 func (sei *SenseIndexEntry) GetTagCount() int {
-    return sei.TagCount
+    return sei.tagCount
 }
 func (sei *SenseIndexEntry) GetSynsetPtr() *Synset {
     return sei.synsetPtr
@@ -73,7 +73,7 @@ func (sei *SenseIndexEntry) GetSynsetPtr() *Synset {
 
 func (e *SenseIndexEntry) ToString() string {
     var pos_str string
-    switch(e.PartOfSpeech) {
+    switch(e.partOfSpeech) {
     case POS_UNSUPPORTED:
         pos_str = "UNSUPPORTED"
     case POS_NOUN:
@@ -90,14 +90,14 @@ func (e *SenseIndexEntry) ToString() string {
 
     return fmt.Sprintf("{ %s, file: %s, lex_id: %d head: %s, head_id: %d, synset_offset: %d, lemma %q sense_number: %d, tag_cnt: %d }",
         pos_str,
-        cLexographerFileNumToName[e.LexographerFilenum],
-        e.LexId,
-        e.HeadWord,
-        e.HeadId,
-        e.SynsetOffset,
-        e.Lemma,
-        e.SenseNumber,
-        e.TagCount)
+        cLexographerFileNumToName[e.lexographerFilenum],
+        e.lexId,
+        e.headWord,
+        e.headId,
+        e.synsetOffset,
+        e.lemma,
+        e.senseNumber,
+        e.tagCount)
 }
 
 func loadSenseIndex(wn *WN, senseIndexFilename string) (senseIndex, error) {

--- a/sense_index.go
+++ b/sense_index.go
@@ -25,47 +25,47 @@ semantic concordance texts.
 
 type senseIndex map[string][]*SenseIndexEntry
 type SenseIndexEntry struct {
-    lemma string
-    partOfSpeech int       // POS tag. (e.g. POS_NOUN, ...)
-    lexographerFilenum int // index into cLexographerFileNumToName
-    lexId int              // identifies a sense within a lemma file (default is 0)
-    headWord string        // OPTIONAL lemma of the first word of the adjective satellite's head synset. (PartOfSpeech of this entry is 5)
-    headId int             // OPTIONAL uniquely identifies head_word in a lexographer file. ( fmt.Sprintf("%s%2d", head_word, head_id) )
+    Lemma string
+    PartOfSpeech int       // POS tag. (e.g. POS_NOUN, ...)
+    LexographerFilenum int // index into cLexographerFileNumToName
+    LexId int              // identifies a sense within a lemma file (default is 0)
+    HeadWord string        // OPTIONAL lemma of the first word of the adjective satellite's head synset. (PartOfSpeech of this entry is 5)
+    HeadId int             // OPTIONAL uniquely identifies head_word in a lexographer file. ( fmt.Sprintf("%s%2d", head_word, head_id) )
 
-    synsetOffset int       // byte offset into <POS>.data file
-    senseNumber int        // sense number within the <POS>.data for the word
-    tagCount int           // number of times the word was tagged in semantic concordance texts
+    SynsetOffset int       // byte offset into <POS>.data file
+    SenseNumber int        // sense number within the <POS>.data for the word
+    TagCount int           // number of times the word was tagged in semantic concordance texts
     synsetPtr *Synset      // back ponter to the underlying synset.
 }
 func (sei *SenseIndexEntry) GetLemma() string {
-    return sei.lemma
+    return sei.Lemma
 }
 func (sei *SenseIndexEntry) GetPartOfSpeech() int {
-    return sei.partOfSpeech
+    return sei.PartOfSpeech
 }
 func (sei *SenseIndexEntry) GetLexographerFilenum() int {
-    return sei.lexographerFilenum
+    return sei.LexographerFilenum
 }
 func (sei *SenseIndexEntry) GetLexographerFilename() string {
-    return cLexographerFileNumToName[sei.lexographerFilenum]
+    return cLexographerFileNumToName[sei.LexographerFilenum]
 }
 func (sei *SenseIndexEntry) GetLexId() int {
-    return sei.lexId
+    return sei.LexId
 }
 func (sei *SenseIndexEntry) GetHeadWord() string {
-    return sei.headWord
+    return sei.HeadWord
 }
 func (sei *SenseIndexEntry) GetHeadId() int {
-    return sei.headId
+    return sei.HeadId
 }
 func (sei *SenseIndexEntry) GetSynsetOffset() int {
-    return sei.synsetOffset
+    return sei.SynsetOffset
 }
 func (sei *SenseIndexEntry) GetSenseNumber() int {
-    return sei.senseNumber
+    return sei.SenseNumber
 }
 func (sei *SenseIndexEntry) GetTagCount() int {
-    return sei.tagCount
+    return sei.TagCount
 }
 func (sei *SenseIndexEntry) GetSynsetPtr() *Synset {
     return sei.synsetPtr
@@ -73,7 +73,7 @@ func (sei *SenseIndexEntry) GetSynsetPtr() *Synset {
 
 func (e *SenseIndexEntry) ToString() string {
     var pos_str string
-    switch(e.partOfSpeech) {
+    switch(e.PartOfSpeech) {
     case POS_UNSUPPORTED:
         pos_str = "UNSUPPORTED"
     case POS_NOUN:
@@ -90,14 +90,14 @@ func (e *SenseIndexEntry) ToString() string {
 
     return fmt.Sprintf("{ %s, file: %s, lex_id: %d head: %s, head_id: %d, synset_offset: %d, lemma %q sense_number: %d, tag_cnt: %d }",
         pos_str,
-        cLexographerFileNumToName[e.lexographerFilenum],
-        e.lexId,
-        e.headWord,
-        e.headId,
-        e.synsetOffset,
-        e.lemma,
-        e.senseNumber,
-        e.tagCount)
+        cLexographerFileNumToName[e.LexographerFilenum],
+        e.LexId,
+        e.HeadWord,
+        e.HeadId,
+        e.SynsetOffset,
+        e.Lemma,
+        e.SenseNumber,
+        e.TagCount)
 }
 
 func loadSenseIndex(wn *WN, senseIndexFilename string) (senseIndex, error) {

--- a/sense_index_test.go
+++ b/sense_index_test.go
@@ -34,8 +34,8 @@ func TestLoadSenseIndex(t *testing.T) {
     actual_computer_files := map[string]int {}
     for _, lemma_index := range computerLemmas {
         t.Logf("%s: %v %s\n", "computer", lemma_index, lemma_index.ToString())
-        actual_computer_pos[lemma_index.PartOfSpeech]++
-        actual_computer_files[LEXOGRAPHER_FILE_NUM_TO_NAME[lemma_index.LexographerFilenum]]++
+        actual_computer_pos[lemma_index.GetPartOfSpeech()]++
+        actual_computer_files[lemma_index.GetLexographerFilename()]++
     }
     validate_pos(t, "computer", expected_computer_pos, actual_computer_pos)
     validate_counts(t, "computer", expected_computer_files, actual_computer_files)
@@ -88,8 +88,8 @@ func TestLoadSenseIndex(t *testing.T) {
     actual_live_files := map[string]int {}
     for _, lemma_index := range liveLemmas {
         t.Logf("%s: %v %s\n", "live", lemma_index, lemma_index.ToString())
-        actual_live_pos[lemma_index.PartOfSpeech]++
-        actual_live_files[LEXOGRAPHER_FILE_NUM_TO_NAME[lemma_index.LexographerFilenum]]++
+        actual_live_pos[lemma_index.GetPartOfSpeech()]++
+        actual_live_files[lemma_index.GetLexographerFilename()]++
     }
     validate_pos(t, "live", expected_live_pos, actual_live_pos)
     validate_counts(t, "live", expected_live_files, actual_live_files)
@@ -117,8 +117,8 @@ func TestLoadSenseIndex(t *testing.T) {
     actual_angus_files := map[string]int {}
     for _, lemma_index := range angusLemmas {
         t.Logf("%s: %v %s\n", "angus", lemma_index, lemma_index.ToString())
-        actual_angus_pos[lemma_index.PartOfSpeech]++
-        actual_angus_files[LEXOGRAPHER_FILE_NUM_TO_NAME[lemma_index.LexographerFilenum]]++
+        actual_angus_pos[lemma_index.GetPartOfSpeech()]++
+        actual_angus_files[lemma_index.GetLexographerFilename()]++
     }
     validate_pos(t, "angus", expected_angus_pos, actual_angus_pos)
     validate_counts(t, "angus", expected_angus_files, actual_angus_files)

--- a/utils.go
+++ b/utils.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-    LEXOGRAPHER_FILE_NUM_TO_NAME = []string{
+    cLexographerFileNumToName = []string{
         "adj.all",            // all adjective clusters
         "adj.pert",           // relational adjectives (pertainyms)
         "adv.all",            // all adverbs
@@ -54,7 +54,7 @@ var (
         "adj.ppl",            // participial adjectives
     }
 
-    RELATIONSHIP_POINTER_SYMBOLS = map[string]int {
+    cRelationshipPointerSymbols = map[string]int {
         // noun relationships
         "!": ANTONYM_RELATIONSHIP,
         "@": HYPERNYM_RELATIONSHIP,
@@ -109,7 +109,7 @@ var (
         // DOMAIN_OF_SYNSET_USAGE_RELATIONSHIP
     }
 
-    RELATIONSHIP_ID_TO_STRING = map[int]string {
+    cRelationshipIdToString = map[int]string {
         ANTONYM_RELATIONSHIP: "antonym",
         HYPERNYM_RELATIONSHIP: "hypernym",
         INSTANCE_HYPERNYM_RELATIONSHIP: "hypernym-instance",
@@ -139,7 +139,7 @@ var (
         PERTAINYM_RELATIONSHIP: "pertainym",
     }
 
-    PART_OF_SPEECH_ID_TO_STRING = []string {
+    cPartOfSpeechIdToString = []string {
       "unsupported",
       "noun",
       "verb",
@@ -147,8 +147,21 @@ var (
       "adv",
       "adj_sat",
     }
-
 )
+
+func PartOfSpeechToString(pos int ) string {
+    if pos < 0 {
+        pos = 0
+    }
+    if pos >= len(cPartOfSpeechIdToString) {
+        pos = 0
+    }
+    return cPartOfSpeechIdToString[pos]
+}
+
+func RelationshipIdToString(rel int) string {
+    return cRelationshipIdToString[rel]
+}
 
 // syntactic category / part of speech
 const POS_UNSUPPORTED int = 0
@@ -225,4 +238,20 @@ func oneCharPosTagToPosId(tag string) int {
     default:
         return POS_UNSUPPORTED
     }
+}
+
+func copyIntArray(a []int) []int {
+    ret := make([]int, len(a))
+    for i, e := range a {
+        ret[i] = e
+    }
+    return ret
+}
+
+func copyStringArray(a []string) []string {
+    ret := make([]string, len(a))
+    for i, e := range a {
+        ret[i] = e
+    }
+    return ret
 }


### PR DESCRIPTION
No longer copies structs
Everything exported via getters

Public methods still exist, in order to keep it backwards compatble.